### PR TITLE
get 조건 개수 상관없이 검색 가능하게 구현

### DIFF
--- a/DIS/client/src/views/Login.vue
+++ b/DIS/client/src/views/Login.vue
@@ -27,8 +27,8 @@ export default {
   },
   methods: {
     loginUser() {
-      const dt = {data: {id: this.id, password:this.password}}
-      axios.post("/api/sign/login", dt)
+      const dt = [{id:this.id} , {password:this.password}]
+      axios.post("/api/elastic/get", dt)
       .then(r => console.log("r: ", JSON.stringify(r, null, 2)))
       .catch(function (error){
         console.log(error.response);

--- a/DIS/server/routes/api/elastic/index.js
+++ b/DIS/server/routes/api/elastic/index.js
@@ -4,17 +4,38 @@ const http = require('http');
 const elasticsearch = require('elasticsearch');
 /* 엘라스틱 검색 */
 /*data1{id:123},data2{password:123}*/ 
-router.post('/get2', function(req, res, next) {
-    let search1 = req.body.data1;
-    let search2 = req.body.data2;
-    console.log(search1);
-    console.log(search2);
+router.post('/get', function(req, res, next) {
+    let search = req.body;
+    // {},{}
+    /*
+    search.forEach(function(key,value){
+        console.log("hohohoho");
+        console.log(key,value);
+    });
+    */
     let client = elasticsearch.Client({
     host: '192.168.0.5:9200'
+    });
+    let frame ={
+        query:{
+            bool:{
+                must:[
+
+                ]
+            }
+        }
+    }
+
+    let obj=new Object();
+    search.forEach(function(element){
+        obj.match=element;
+        frame.query.bool.must.push(obj);
     });
     client.search({
     index: 'test',
     type: '_doc',
+    body: frame,
+    /*
     body: {
         query: {
             bool: {
@@ -25,9 +46,10 @@ router.post('/get2', function(req, res, next) {
             }
         }
     }
+    */
     }).then(function(response) {
-    let hits = response.hits.hits;
-    console.log(hits);
+    let hits = response.hits.hits;//결과배열
+    console.log(hits[0]._source);//결과 첫번째의 _source의 id 출력
     }, function(error) {
     console.trace(error.message);
     });


### PR DESCRIPTION
## Description

기존 elastic검색 조건 수마다 api가 필요했던 부분을 검색 조건 수에 상관없이 한개의 api가 처리 할 수 있도록 수정

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Did you test this on all browsers

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Internet Explorer